### PR TITLE
plugins/snapd-uefi/tests: add test data for snapd-uefi plugin

### DIFF
--- a/ci-tests/plugins/snapd-uefi/tests/KEK-8be4df61-93ca-11d2-aa0d-00e098032b8c
+++ b/ci-tests/plugins/snapd-uefi/tests/KEK-8be4df61-93ca-11d2-aa0d-00e098032b8c
@@ -1,0 +1,1 @@
+../../uefi-dbx/tests/KEK-8be4df61-93ca-11d2-aa0d-00e098032b8c

--- a/ci-tests/plugins/snapd-uefi/tests/dbx-d719b2cb-3d3a-4596-a3bc-dad00e67656f
+++ b/ci-tests/plugins/snapd-uefi/tests/dbx-d719b2cb-3d3a-4596-a3bc-dad00e67656f
@@ -1,0 +1,1 @@
+../../uefi-dbx/tests/dbx-d719b2cb-3d3a-4596-a3bc-dad00e67656f

--- a/ci-tests/plugins/snapd-uefi/tests/dbx-update.auth
+++ b/ci-tests/plugins/snapd-uefi/tests/dbx-update.auth
@@ -1,0 +1,1 @@
+../../uefi-dbx/tests/dbx-update.auth


### PR DESCRIPTION
Reuse test data from uefi-dbx.

Needed for: https://github.com/fwupd/fwupd/issues/10082